### PR TITLE
test(web): cover the UI with a Playwright suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,12 @@ Moneta is an Android expense tracker. The entire user interface is a web app (pl
 
 * `web/main.js` — the whole app: state, UI components, persistence, import/export.
 * `web/index.html` — page shell, custom CSS, import map, module script tag. `%VERSION%` is substituted at build time.
-* `web/package.json` — npm deps used purely as a source of static assets (Bootstrap, Solid, Material icons).
+* `web/package.json` — npm deps used purely as a source of static assets (Bootstrap, Solid, Material icons), plus `@playwright/test` for the UI suite.
+* `web/test/` — Node unit tests over the domain layer of `main.js`.
+* `web/e2e/` — Playwright UI suite: `fixtures.js` (page object, dialog recorder, seeding), `server.js` (serves the app for the tests), and the specs. `web/playwright.config.js` configures it.
 * `android/src/main/java/net/akrain/moneta/MainActivity.java` — WebView host plus the `Android` JavaScript bridge (file save/pick).
 * `android/src/main/assets/web/` — generated; build output copied here, not in git.
-* `scripts/` — `build`, `install`, `serve`, `emulator`.
+* `scripts/` — `build`, `install`, `serve`, `emulator`, `test`, `e2e`.
 * `shell.nix` — Android SDK, Gradle (JDK 17), Node.js.
 
 ## Working in the Nix shell
@@ -30,8 +32,11 @@ nix-shell --run "scripts/build"
 * `scripts/emulator` creates the `moneta` AVD if missing and starts it.
 
 * `scripts/test` runs the unit tests in `web/test/` with Node's built-in runner, under two timezones. No linter is configured.
+* `scripts/e2e` runs the Playwright UI suite in `web/e2e/`, also under two timezones (one Chromium project each for Asia/Kolkata and America/New_York). It takes Playwright's own arguments, so `scripts/e2e --project=east-of-utc add-expense --headed` works. It starts its own server on port 8099 from `web/e2e/server.js`, which serves `web/index.html`, `web/main.js` and the four Solid modules under the same names `scripts/build` gives them — so no build is needed, and the import map resolves exactly as it does on the device.
 
-The tests cover the domain layer of `main.js` (validation, form conversion, stored JSON, store actions, import) but not the Solid components, so also verify UI changes by loading the app (browser via `scripts/serve`, or emulator) and exercising the affected flow.
+The unit tests cover the domain layer of `main.js` (validation, form conversion, stored JSON, store actions, import); the Playwright suite covers the Solid components and the flows through them (adding, editing, deleting, grouping and totals, blurred amounts, persistence and reload, import/export in both the browser and the Android branch). Between them a UI change should be provable without a device, but a change to the bridge itself still needs an emulator run.
+
+Writing UI tests: `web/e2e/fixtures.js` holds a `MonetaApp` page object with the locators, `app.open({ expenses, now, android })` for seeding `localStorage`, fixing the clock and installing a stand-in bridge before the page loads, and a `dialogs` fixture — the app talks to the user through `alert` and `confirm`, which Playwright dismisses unless a test says `dialogs.acceptAll()`.
 
 Also, if you need to control browser, you can use `playwright-cli`:
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -8,7 +8,8 @@ _Reference context — observed facts and standing conventions for this project,
 ## Conventions
 
 - `main.js` has no import-time side effects; `index.html`'s inline module imports `main` and calls it. Why: the Node test suite imports `main.js`, and only `render` needs a DOM. How to apply: keep new top-level code in `main.js` side-effect free.
-- UI changes are verified in a real browser; the unit tests cover only the domain layer. Why: nothing else catches wiring errors with no compile step. How to apply: `scripts/serve`, then drive the page with `playwright-cli`.
+- UI changes are verified in a real browser; the Node unit tests cover only the domain layer. Why: nothing else catches wiring errors with no compile step. How to apply: `scripts/e2e` runs the Playwright suite in `web/e2e/` (July 2026); for exploratory poking, `scripts/serve` plus `playwright-cli`.
+- The UI suite reaches the app through `web/e2e/fixtures.js`: locators live on the `MonetaApp` page object, and anything that must exist before `main()` runs — seeded expenses, a fixed clock, the `Android` bridge — is set up by `app.open()`. Why: the app carries no test hooks, so the markup it happens to render is described in one place. How to apply: add locators and setup there rather than in a spec.
 - Behaviour changes bundled into a refactor are agreed with the user up front and reported individually afterwards. Why: in a port, a silent fix is indistinguishable from a porting error. How to apply: name each fix when handing back the work.
 - A defect found mid-task that was not part of the agreed scope is reported, not fixed. Why: it keeps an agreed change set reviewable. How to apply: work around it in tests and hand the decision back.
 
@@ -18,7 +19,10 @@ _Reference context — observed facts and standing conventions for this project,
 - `playwright-cli click` against this app reports "performing click action" and then stalls without the click taking effect. Driving the DOM through `playwright-cli eval` with `element.click()` works reliably.
 - `playwright-cli upload` fails on the import flow with "can only be used when there is related modal state present", because the `<input type=file>` is created and clicked programmatically.
 - Import can be driven in-page by patching `HTMLInputElement.prototype.click` to set `files` from a `DataTransfer` holding a `File`, then dispatching `change`.
-- Stubbing `window.alert` and `window.confirm` inside a `playwright-cli eval` is the practical way to exercise the validation and delete-confirmation paths; real dialogs block the evaluation.
+- Stubbing `window.alert` and `window.confirm` inside a `playwright-cli eval` is the practical way to exercise the validation and delete-confirmation paths; real dialogs block the evaluation. Under `@playwright/test` a `page.on("dialog")` listener does the same job, and without one Playwright dismisses every dialog — which reads as "no" to the delete confirmation.
+- A UI test that stops the clock and then adds several expenses gives them all one id, because ids are creation timestamps. `app.tick()` in the e2e fixtures moves a fixed clock forward between saves.
+- A `page.addInitScript` that seeds `localStorage` runs again on reload, so it has to write only when the key is absent; otherwise a reload restores the seed and hides what the app saved.
+- `@playwright/test` must match the Chromium build already downloaded, or every test fails at launch with "Executable doesn't exist"; `npx playwright install chromium` (what `scripts/e2e` runs) fetches the matching one.
 
 ## Decisions
 
@@ -30,6 +34,9 @@ _Reference context — observed facts and standing conventions for this project,
 - The modal and the import path share one `expenseError` check (July 2026), and the form's wording won: a blank imported description now reports "Description cannot be empty." rather than "Empty description."
 - An expense with no `categories` field loads as one with none (July 2026). Why: both the pre-refactor code and the first sorting version blanked the app at startup on such data, so tolerating it is a deliberate improvement.
 - Day headings call `formatDay`, a one-line delegate to `toIsoDate`, rather than `toIsoDate` itself. Why: the heading is free to stop looking like a stored date without touching the storage format.
+- The Playwright suite serves the app from its own `web/e2e/server.js` rather than from `scripts/serve` (July 2026). Why: `scripts/serve` publishes the *built* assets, which would make the UI suite depend on a full Android build; the test server maps the same URL names straight onto `web/` and `node_modules`, so no build step is involved and `index.html` is exercised unchanged.
+- The UI suite runs every spec twice, in Asia/Kolkata and America/New_York (July 2026), as `scripts/test` does. Why: the UI is full of dates, and a day that slips only west of the meridian must not pass unnoticed. How to apply: expectations about "today" are computed in the page, not in Node, since only the browser context carries the project's timezone.
+- The Android bridge is exercised in the browser against a recording stand-in installed before load, not on a device (July 2026). Why: it pins the JavaScript side's contract — `Android.createFile(filename, json)` and `Android.pickFile(callback)` — which is what the port could break; the Java side still needs an emulator run.
 
 ## Open Questions
 

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+cd "${SCRIPT_DIR}/../web"
+
+npm install
+# A no-op once the matching Chromium build is on the machine.
+npx playwright install chromium
+
+# The suite serves the app itself (web/e2e/server.js) and runs every spec in
+# two timezones, east and west of UTC, as the unit tests do.
+npx playwright test "$@"

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+test-results
+playwright-report

--- a/web/e2e/add-expense.spec.js
+++ b/web/e2e/add-expense.spec.js
@@ -1,0 +1,188 @@
+import { test, expect } from "./fixtures.js";
+
+test.describe("adding an expense", () => {
+  test.beforeEach(async ({ app }) => {
+    await app.open();
+  });
+
+  test("opens a blank dialog dated today", async ({ app }) => {
+    await app.openNewExpense();
+
+    await expect(app.modalTitle).toHaveText("New Expense");
+    await expect(app.submitButton).toHaveText("Save");
+    await expect(app.amountInput).toHaveValue("");
+    await expect(app.descriptionInput).toHaveValue("");
+    await expect(app.dateInput).toHaveValue(await app.todayIso());
+    await expect(app.categoriesInput).toHaveValue("");
+    // Only the edit dialog offers deletion.
+    await expect(app.deleteButton).toHaveCount(0);
+  });
+
+  test("labels every field", async ({ app, page }) => {
+    await app.openNewExpense();
+
+    await expect(page.getByLabel("Amount")).toHaveAttribute("type", "number");
+    await expect(page.getByLabel("Description")).toHaveAttribute("type", "text");
+    await expect(page.getByLabel("Date")).toHaveAttribute("type", "date");
+    await expect(page.getByLabel("Categories")).toHaveAttribute("type", "text");
+    await expect(app.amountInput).toHaveAttribute("placeholder", "0.00");
+    await expect(app.amountInput).toHaveAttribute("step", "0.01");
+  });
+
+  test("lists the saved expense under today", async ({ app }) => {
+    const today = await app.todayIso();
+
+    await app.addExpense({
+      amount: "12.50",
+      description: "Groceries",
+      categories: "food",
+    });
+
+    await expect(app.emptyMessage).toHaveCount(0);
+    await expect(app.expenseItems).toHaveCount(1);
+    await expect(app.dayGroup(today)).toBeVisible();
+    await expect(app.expenseItem("Groceries")).toBeVisible();
+    await expect(app.amountOf("Groceries")).toHaveText("-$12.50");
+    await expect(app.categoriesOf("Groceries")).toHaveText("food");
+  });
+
+  test("adds the amount to the day and month totals", async ({ app }) => {
+    const today = await app.todayIso();
+
+    await app.addExpense({ amount: "12.50", description: "Groceries" });
+
+    await expect(app.dayTotal(today)).toHaveText("$12.50");
+    await expect(app.totalSpent).toHaveText("$12.50");
+  });
+
+  test("stores the expense in the JSON shape the device holds", async ({
+    app,
+  }) => {
+    const today = await app.todayIso();
+
+    await app.addExpense({
+      amount: "12.50",
+      description: "Groceries",
+      categories: "food shopping",
+    });
+
+    expect(await app.stored()).toEqual([
+      {
+        id: expect.any(Number),
+        amount: 12.5,
+        description: "Groceries",
+        date: today,
+        categories: ["food", "shopping"],
+      },
+    ]);
+    // Written the way `serializeExpenses` writes it: indented, dates as text.
+    expect(await app.storedJson()).toContain('\n  {\n    "id"');
+  });
+
+  test("shows the Saved bubble", async ({ app }) => {
+    await app.addExpense({ amount: "1", description: "Coffee" });
+
+    await expect(app.saveNotice).toHaveText("Saved");
+  });
+
+  test("trims the description and normalises categories", async ({ app }) => {
+    await app.addExpense({
+      amount: "3",
+      description: "   Coffee   ",
+      categories: "  Shopping   FOOD  ",
+    });
+
+    await expect(app.expenseItem("Coffee")).toBeVisible();
+    await expect(app.categoriesOf("Coffee")).toHaveText("food, shopping");
+    expect(await app.stored()).toEqual([
+      expect.objectContaining({
+        description: "Coffee",
+        categories: ["food", "shopping"],
+      }),
+    ]);
+  });
+
+  test("shows no category line when none were given", async ({ app }) => {
+    await app.addExpense({ amount: "3", description: "Coffee" });
+
+    await expect(app.categoriesOf("Coffee")).toHaveCount(0);
+    expect(await app.stored()).toEqual([
+      expect.objectContaining({ categories: [] }),
+    ]);
+  });
+
+  test("accepts a past date and heads the list with that day", async ({
+    app,
+  }) => {
+    const yesterday = await app.isoDaysFromToday(-1);
+
+    await app.addExpense({
+      amount: "5",
+      description: "Bus",
+      date: yesterday,
+    });
+
+    await expect(app.dayGroup(yesterday)).toBeVisible();
+    expect(await app.stored()).toEqual([
+      expect.objectContaining({ date: yesterday }),
+    ]);
+  });
+
+  test("keeps fractional amounts to the cent", async ({ app }) => {
+    await app.addExpense({ amount: "0.05", description: "Sweet" });
+
+    await expect(app.amountOf("Sweet")).toHaveText("-$0.05");
+    await expect(app.totalSpent).toHaveText("$0.05");
+  });
+
+  test("opens blank again after a save", async ({ app }) => {
+    await app.addExpense({
+      amount: "12.50",
+      description: "Groceries",
+      categories: "food",
+    });
+
+    await app.openNewExpense();
+
+    await expect(app.amountInput).toHaveValue("");
+    await expect(app.descriptionInput).toHaveValue("");
+    await expect(app.categoriesInput).toHaveValue("");
+    await expect(app.dateInput).toHaveValue(await app.todayIso());
+  });
+
+  test("Cancel discards the expense", async ({ app }) => {
+    await app.openNewExpense();
+    await app.fillForm({ amount: "12.50", description: "Groceries" });
+
+    await app.cancelButton.click();
+
+    await expect(app.modal).toHaveCount(0);
+    await expect(app.emptyMessage).toBeVisible();
+    expect(await app.stored()).toBe(null);
+  });
+
+  test("the close button discards the expense", async ({ app }) => {
+    await app.openNewExpense();
+    await app.fillForm({ amount: "12.50", description: "Groceries" });
+
+    await app.closeButton.click();
+
+    await expect(app.modal).toHaveCount(0);
+    await expect(app.expenseItems).toHaveCount(0);
+    expect(await app.stored()).toBe(null);
+  });
+
+  test("adds a second expense to the same day", async ({ app }) => {
+    const today = await app.todayIso();
+
+    await app.addExpense({ amount: "10", description: "Lunch" });
+    await app.addExpense({ amount: "2.25", description: "Coffee" });
+
+    await expect(app.dayGroups).toHaveCount(1);
+    await expect(app.expensesOf(today)).toHaveCount(2);
+    await expect(app.dayTotal(today)).toHaveText("$12.25");
+    await expect(app.totalSpent).toHaveText("$12.25");
+    // Ids are creation timestamps and a day lists the newest first.
+    expect(await app.listedDescriptions()).toEqual(["Coffee", "Lunch"]);
+  });
+});

--- a/web/e2e/amount-blur.spec.js
+++ b/web/e2e/amount-blur.spec.js
@@ -1,0 +1,103 @@
+// Amounts are blurred until the user reveals them, and every amount on the
+// page shares the one `showNumbers` signal.
+import { test, expect } from "./fixtures.js";
+
+const blurred = async (locator) => expect(locator).toHaveClass("blur-text");
+const revealed = async (locator) => expect(locator).toHaveClass("");
+
+const expenses = [
+  {
+    id: 1,
+    amount: 12.5,
+    description: "Groceries",
+    date: "2026-02-12",
+    categories: [],
+  },
+  {
+    id: 2,
+    amount: 3.25,
+    description: "Coffee",
+    date: "2026-02-10",
+    categories: [],
+  },
+];
+
+test.describe("revealing amounts", () => {
+  test.beforeEach(async ({ app }) => {
+    await app.open({ now: "2026-02-12T12:00:00Z", expenses });
+  });
+
+  test("starts with every amount blurred", async ({ app }) => {
+    await blurred(app.totalSpent);
+    await blurred(app.dayTotal("2026-02-12"));
+    await blurred(app.dayTotal("2026-02-10"));
+    await blurred(app.amountOf("Groceries"));
+    await blurred(app.amountOf("Coffee"));
+  });
+
+  test("the monthly total toggles them all", async ({ app }) => {
+    await app.totalSpentRow.click();
+
+    await revealed(app.totalSpent);
+    await revealed(app.dayTotal("2026-02-12"));
+    await revealed(app.amountOf("Groceries"));
+
+    await app.totalSpentRow.click();
+
+    await blurred(app.totalSpent);
+    await blurred(app.amountOf("Groceries"));
+  });
+
+  test("a day heading toggles them all", async ({ app }) => {
+    await app.dayGroup("2026-02-10").locator("strong").click();
+
+    await revealed(app.totalSpent);
+    await revealed(app.dayTotal("2026-02-12"));
+    await revealed(app.amountOf("Coffee"));
+  });
+
+  test("an expense's amount toggles them without opening the dialog", async ({
+    app,
+  }) => {
+    await app.amountOf("Groceries").click();
+
+    await expect(app.modal).toHaveCount(0);
+    await revealed(app.totalSpent);
+    await revealed(app.amountOf("Coffee"));
+
+    await app.amountOf("Groceries").click();
+
+    await expect(app.modal).toHaveCount(0);
+    await blurred(app.totalSpent);
+  });
+
+  test("tapping the rest of the row opens the dialog instead", async ({
+    app,
+  }) => {
+    await app.expenseItem("Groceries").locator("div").first().click();
+
+    await expect(app.modal).toBeVisible();
+    await expect(app.descriptionInput).toHaveValue("Groceries");
+  });
+
+  test("a newly added expense joins the revealed state", async ({ app }) => {
+    await app.totalSpentRow.click();
+
+    await app.addExpense({
+      amount: "1",
+      description: "Sweet",
+      date: "2026-02-12",
+    });
+
+    await revealed(app.amountOf("Sweet"));
+  });
+
+  test("amounts are blurred again after a reload", async ({ app, page }) => {
+    await app.totalSpentRow.click();
+    await revealed(app.totalSpent);
+
+    await page.reload();
+
+    await blurred(app.totalSpent);
+  });
+});

--- a/web/e2e/android-bridge.spec.js
+++ b/web/e2e/android-bridge.spec.js
@@ -1,0 +1,131 @@
+// Inside the app the WebView injects an `Android` object and import/export go
+// through it instead of through the browser's download and file picker. The
+// object is absent in a plain browser, so both branches have to keep working.
+import { test, expect, androidCalls, respondToPickFile } from "./fixtures.js";
+
+const stored = [
+  {
+    id: 1,
+    amount: 12.5,
+    description: "Groceries",
+    date: "2026-02-12",
+    categories: ["food"],
+  },
+];
+
+const imported = [
+  {
+    id: 10,
+    amount: 5,
+    description: "Bus",
+    date: "2026-02-11",
+    categories: ["travel"],
+  },
+];
+
+test.describe("with the Android bridge present", () => {
+  test.beforeEach(async ({ app }) => {
+    await app.open({
+      now: "2026-02-12T12:00:00Z",
+      expenses: stored,
+      android: true,
+    });
+  });
+
+  test("export hands the file to the host, not to the browser", async ({
+    app,
+    page,
+  }) => {
+    let downloads = 0;
+    page.on("download", () => (downloads += 1));
+
+    await app.exportButton.click();
+
+    const { createFile } = await androidCalls(page);
+    expect(createFile).toHaveLength(1);
+    expect(createFile[0].filename).toBe("moneta-2026-02-12.json");
+    expect(JSON.parse(createFile[0].content)).toEqual(stored);
+    expect(downloads).toBe(0);
+    await expect(page.locator("a[download]")).toHaveCount(0);
+  });
+
+  test("import asks the host for a file", async ({ app, page }) => {
+    await app.importButton.click();
+
+    await expect.poll(async () => (await androidCalls(page)).pickFile).toBe(1);
+    // No browser file input is created on this branch.
+    await expect(page.locator("input[type=file]")).toHaveCount(0);
+  });
+
+  test("the file the host returns replaces the expenses", async ({
+    app,
+    page,
+    dialogs,
+  }) => {
+    await app.importButton.click();
+    await expect.poll(async () => (await androidCalls(page)).pickFile).toBe(1);
+
+    await respondToPickFile(page, JSON.stringify(imported));
+
+    await expect(app.expenseItem("Bus")).toBeVisible();
+    await expect(app.expenseItem("Groceries")).toHaveCount(0);
+    await expect(app.categoriesOf("Bus")).toHaveText("travel");
+    await expect(app.saveNotice).toHaveText("Saved");
+    expect(await app.stored()).toEqual(imported);
+    expect(dialogs.messages).toEqual([]);
+  });
+
+  test("a file the host returns that cannot be read is refused", async ({
+    app,
+    page,
+    dialogs,
+  }) => {
+    await app.importButton.click();
+    await expect.poll(async () => (await androidCalls(page)).pickFile).toBe(1);
+
+    await respondToPickFile(page, "not json");
+
+    await dialogs.expectMessage(
+      "Failed to import expenses: Unexpected token 'o', \"not json\" is not valid JSON",
+    );
+    await expect(app.expenseItem("Groceries")).toBeVisible();
+    expect(await app.stored()).toEqual(stored);
+  });
+
+  test("an invalid expense from the host is refused", async ({
+    app,
+    page,
+    dialogs,
+  }) => {
+    await app.importButton.click();
+    await expect.poll(async () => (await androidCalls(page)).pickFile).toBe(1);
+
+    await respondToPickFile(page, JSON.stringify([{ ...imported[0], id: null }]));
+
+    await dialogs.expectMessage("File contains errors.");
+    await expect(app.expenseItem("Groceries")).toBeVisible();
+  });
+
+  test("everything else still works", async ({ app }) => {
+    await app.addExpense({
+      amount: "5",
+      description: "Bus",
+      date: "2026-02-12",
+    });
+
+    await expect(app.expenseItem("Bus")).toBeVisible();
+    await expect(app.totalSpent).toHaveText("$17.50");
+  });
+});
+
+test.describe("without the Android bridge", () => {
+  test("export falls back to a browser download", async ({ app, page }) => {
+    await app.open({ now: "2026-02-12T12:00:00Z", expenses: stored });
+
+    const download = page.waitForEvent("download");
+    await app.exportButton.click();
+
+    expect((await download).suggestedFilename()).toBe("moneta-2026-02-12.json");
+    expect(await page.evaluate(() => "Android" in window)).toBe(false);
+  });
+});

--- a/web/e2e/app-shell.spec.js
+++ b/web/e2e/app-shell.spec.js
@@ -1,0 +1,93 @@
+import { test, expect } from "./fixtures.js";
+import { VERSION } from "./server.js";
+
+test.describe("the empty app", () => {
+  test.beforeEach(async ({ app }) => {
+    await app.open();
+  });
+
+  test("shows the current month and nothing spent", async ({ app }) => {
+    await expect(app.monthTitle).toHaveText(await app.monthName());
+    await expect(app.totalSpentRow).toContainText("Total Spent:");
+    await expect(app.totalSpent).toHaveText("$0.00");
+  });
+
+  test("says there are no expenses yet", async ({ app }) => {
+    await expect(app.emptyMessage).toHaveText("No expenses yet");
+    await expect(app.expenseItems).toHaveCount(0);
+    await expect(app.dayGroups).toHaveCount(0);
+  });
+
+  test("offers import, export and a new expense button", async ({ app }) => {
+    await expect(app.expenseCard.getByRole("heading")).toHaveText("Expenses");
+    await expect(app.importButton).toBeVisible();
+    await expect(app.exportButton).toBeVisible();
+    await expect(app.newExpenseButton).toBeVisible();
+    await expect(app.newExpenseButton).toHaveText("+");
+  });
+
+  test("shows the build version", async ({ app }) => {
+    await expect(app.version).toHaveText("Version: " + VERSION);
+  });
+
+  test("opens no dialog and writes nothing until something happens", async ({
+    app,
+  }) => {
+    await expect(app.modal).toHaveCount(0);
+    await expect(app.saveNotice).toHaveCount(0);
+    expect(await app.stored()).toBe(null);
+  });
+
+  test("keeps the new expense button reachable above a long list", async ({
+    app,
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const expenses = Array.from({ length: 40 }, (_, index) => ({
+        id: index + 1,
+        amount: 1,
+        description: "Item " + index,
+        date: "2026-02-12",
+        categories: [],
+      }));
+      window.localStorage.setItem("expenses", JSON.stringify(expenses));
+    });
+    await page.reload();
+    await expect(app.expenseItems).toHaveCount(40);
+    await page.mouse.wheel(0, 4000);
+    await expect(app.newExpenseButton).toBeInViewport();
+  });
+
+  test("lays out without sideways scrolling on a narrow screen", async ({
+    app,
+    page,
+  }) => {
+    await page.setViewportSize({ width: 320, height: 640 });
+    await app.addExpense({
+      amount: "1234.56",
+      description: "A description long enough to test wrapping on a phone",
+      categories: "one two three four five six",
+    });
+
+    expect(
+      await page.evaluate(
+        () =>
+          document.documentElement.scrollWidth <=
+          document.documentElement.clientWidth,
+      ),
+    ).toBe(true);
+    await expect(app.newExpenseButton).toBeInViewport();
+  });
+
+  test("loads without console errors", async ({ page, app }) => {
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(String(error)));
+    page.on("console", (message) => {
+      if (message.type() === "error") errors.push(message.text());
+    });
+    await app.open();
+    await app.openNewExpense();
+    await app.cancelButton.click();
+    expect(errors).toEqual([]);
+  });
+});

--- a/web/e2e/edit-expense.spec.js
+++ b/web/e2e/edit-expense.spec.js
@@ -1,0 +1,232 @@
+import { test, expect } from "./fixtures.js";
+
+// Seeded expenses carry explicit ids; ids minted by the UI are timestamps.
+const groceries = {
+  id: 1,
+  amount: 12.5,
+  description: "Groceries",
+  date: "2026-02-12",
+  categories: ["food", "shopping"],
+};
+const coffee = {
+  id: 2,
+  amount: 3.25,
+  description: "Coffee",
+  date: "2026-02-12",
+  categories: [],
+};
+
+test.describe("editing an expense", () => {
+  test.beforeEach(async ({ app }) => {
+    await app.open({ expenses: [groceries, coffee] });
+  });
+
+  test("opens the tapped expense, filled in", async ({ app }) => {
+    await app.openExpense("Groceries");
+
+    await expect(app.modalTitle).toHaveText("Edit Expense");
+    await expect(app.submitButton).toHaveText("Update");
+    await expect(app.amountInput).toHaveValue("12.5");
+    await expect(app.descriptionInput).toHaveValue("Groceries");
+    await expect(app.dateInput).toHaveValue("2026-02-12");
+    await expect(app.categoriesInput).toHaveValue("food shopping");
+    await expect(app.deleteButton).toBeVisible();
+  });
+
+  test("opens the other expense when that one is tapped", async ({ app }) => {
+    await app.openExpense("Coffee");
+
+    await expect(app.descriptionInput).toHaveValue("Coffee");
+    await expect(app.amountInput).toHaveValue("3.25");
+    await expect(app.categoriesInput).toHaveValue("");
+  });
+
+  test("saves the changes and keeps the id", async ({ app }) => {
+    await app.openExpense("Groceries");
+
+    await app.fillForm({
+      amount: "20",
+      description: "Big groceries",
+      categories: "food",
+    });
+    await app.submit();
+
+    await expect(app.modal).toHaveCount(0);
+    expect(await app.listedDescriptions()).toEqual([
+      "Coffee",
+      "Big groceries",
+    ]);
+    await expect(app.amountOf("Big groceries")).toHaveText("-$20.00");
+    await expect(app.categoriesOf("Big groceries")).toHaveText("food");
+    expect(await app.stored()).toEqual([
+      {
+        id: 1,
+        amount: 20,
+        description: "Big groceries",
+        date: "2026-02-12",
+        categories: ["food"],
+      },
+      coffee,
+    ]);
+  });
+
+  test("leaves the other expenses untouched", async ({ app }) => {
+    await app.openExpense("Coffee");
+    await app.fillForm({ amount: "4" });
+    await app.submit();
+
+    await expect(app.amountOf("Groceries")).toHaveText("-$12.50");
+    await expect(app.amountOf("Coffee")).toHaveText("-$4.00");
+    await expect(app.dayTotal("2026-02-12")).toHaveText("$16.50");
+  });
+
+  test("moves the expense when its date changes", async ({ app }) => {
+    await app.openExpense("Coffee");
+
+    await app.fillForm({ date: "2026-02-10" });
+    await app.submit();
+
+    await expect(app.dayGroups).toHaveCount(2);
+    await expect(app.expensesOf("2026-02-12")).toHaveCount(1);
+    await expect(app.expensesOf("2026-02-10")).toHaveCount(1);
+    await expect(app.dayTotal("2026-02-12")).toHaveText("$12.50");
+    await expect(app.dayTotal("2026-02-10")).toHaveText("$3.25");
+    expect(await app.listedDays()).toEqual(["2026-02-12", "2026-02-10"]);
+  });
+
+  test("can clear the categories", async ({ app }) => {
+    await app.openExpense("Groceries");
+
+    await app.fillForm({ categories: "  " });
+    await app.submit();
+
+    await expect(app.categoriesOf("Groceries")).toHaveCount(0);
+    expect(await app.stored()).toEqual([
+      expect.objectContaining({ id: 1, categories: [] }),
+      coffee,
+    ]);
+  });
+
+  test("Cancel keeps the expense as it was", async ({ app }) => {
+    await app.openExpense("Groceries");
+    await app.fillForm({ amount: "99", description: "Changed" });
+
+    await app.cancelButton.click();
+
+    await expect(app.modal).toHaveCount(0);
+    await expect(app.expenseItem("Groceries")).toBeVisible();
+    await expect(app.amountOf("Groceries")).toHaveText("-$12.50");
+    // Nothing was saved, so storage still holds what was seeded.
+    expect(await app.stored()).toEqual([groceries, coffee]);
+  });
+
+  test("the close button keeps the expense as it was", async ({ app }) => {
+    await app.openExpense("Groceries");
+    await app.fillForm({ amount: "99" });
+
+    await app.closeButton.click();
+
+    await expect(app.modal).toHaveCount(0);
+    await expect(app.amountOf("Groceries")).toHaveText("-$12.50");
+  });
+
+  test("reopening after a cancel shows the stored values again", async ({
+    app,
+  }) => {
+    await app.openExpense("Groceries");
+    await app.fillForm({ amount: "99" });
+    await app.cancelButton.click();
+
+    await app.openExpense("Groceries");
+
+    await expect(app.amountInput).toHaveValue("12.5");
+  });
+
+  test("tapping an amount reveals numbers instead of opening the dialog", async ({
+    app,
+  }) => {
+    await app.amountOf("Groceries").click();
+
+    await expect(app.modal).toHaveCount(0);
+    await expect(app.amountOf("Groceries")).not.toHaveClass(/blur-text/);
+  });
+});
+
+test.describe("deleting an expense", () => {
+  test.beforeEach(async ({ app }) => {
+    await app.open({ expenses: [groceries, coffee] });
+  });
+
+  test("asks before deleting", async ({ app, dialogs }) => {
+    await app.openExpense("Groceries");
+
+    await app.deleteButton.click();
+
+    await dialogs.expectMessage("Are you sure?");
+  });
+
+  test("keeps the expense when the question is declined", async ({
+    app,
+    dialogs,
+  }) => {
+    await app.openExpense("Groceries");
+
+    await app.deleteButton.click();
+
+    await dialogs.expectMessage("Are you sure?");
+    await expect(app.modal).toBeVisible();
+    await expect(app.expenseItems).toHaveCount(2);
+    expect(await app.stored()).toEqual([groceries, coffee]);
+  });
+
+  test("removes the expense when the question is accepted", async ({
+    app,
+    dialogs,
+  }) => {
+    dialogs.acceptAll();
+    await app.openExpense("Groceries");
+
+    await app.deleteButton.click();
+
+    await expect(app.modal).toHaveCount(0);
+    await expect(app.expenseItem("Groceries")).toHaveCount(0);
+    await expect(app.expenseItems).toHaveCount(1);
+    await expect(app.dayTotal("2026-02-12")).toHaveText("$3.25");
+    expect(await app.stored()).toEqual([coffee]);
+  });
+
+  test("deleting the last expense empties the list", async ({
+    app,
+    dialogs,
+  }) => {
+    dialogs.acceptAll();
+
+    for (const description of ["Groceries", "Coffee"]) {
+      await app.openExpense(description);
+      await app.deleteButton.click();
+      await expect(app.modal).toHaveCount(0);
+    }
+
+    await expect(app.emptyMessage).toHaveText("No expenses yet");
+    await expect(app.dayGroups).toHaveCount(0);
+    expect(await app.stored()).toEqual([]);
+  });
+
+  // Reading the edited expense out of the store has to stay inside `untrack`:
+  // otherwise deleting it re-runs the dialog expression with a stale id.
+  test("deleting raises no error from the dialog", async ({
+    app,
+    page,
+    dialogs,
+  }) => {
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(String(error)));
+    dialogs.acceptAll();
+
+    await app.openExpense("Groceries");
+    await app.deleteButton.click();
+    await expect(app.modal).toHaveCount(0);
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/web/e2e/expense-list.spec.js
+++ b/web/e2e/expense-list.spec.js
@@ -1,0 +1,129 @@
+import { test, expect } from "./fixtures.js";
+
+const expense = (overrides) => ({
+  id: 1,
+  amount: 10,
+  description: "Lunch",
+  date: "2026-02-12",
+  categories: [],
+  ...overrides,
+});
+
+test.describe("the expense list", () => {
+  test("groups expenses by day, newest day first", async ({ app }) => {
+    await app.open({
+      expenses: [
+        expense({ id: 1, description: "Older", date: "2026-02-10" }),
+        expense({ id: 2, description: "Newest", date: "2026-02-14" }),
+        expense({ id: 3, description: "Middle", date: "2026-02-12" }),
+      ],
+    });
+
+    await expect(app.dayGroups).toHaveCount(3);
+    expect(await app.listedDays()).toEqual([
+      "2026-02-14",
+      "2026-02-12",
+      "2026-02-10",
+    ]);
+    expect(await app.listedDescriptions()).toEqual([
+      "Newest",
+      "Middle",
+      "Older",
+    ]);
+  });
+
+  test("lists a day's expenses newest first, by id", async ({ app }) => {
+    await app.open({
+      expenses: [
+        expense({ id: 100, description: "First" }),
+        expense({ id: 300, description: "Third" }),
+        expense({ id: 200, description: "Second" }),
+      ],
+    });
+
+    await expect(app.expensesOf("2026-02-12")).toHaveCount(3);
+    expect(await app.listedDescriptions()).toEqual([
+      "Third",
+      "Second",
+      "First",
+    ]);
+  });
+
+  test("totals each day separately", async ({ app }) => {
+    await app.open({
+      expenses: [
+        expense({ id: 1, amount: 10, date: "2026-02-12" }),
+        expense({ id: 2, amount: 2.5, date: "2026-02-12" }),
+        expense({ id: 3, amount: 7.25, date: "2026-02-10" }),
+      ],
+    });
+
+    await expect(app.dayTotal("2026-02-12")).toHaveText("$12.50");
+    await expect(app.dayTotal("2026-02-10")).toHaveText("$7.25");
+  });
+
+  test("shows each expense as a negative amount", async ({ app }) => {
+    await app.open({ expenses: [expense({ amount: 4.5 })] });
+
+    await expect(app.amountOf("Lunch")).toHaveText("-$4.50");
+  });
+
+  test("joins categories with commas, in sorted order", async ({ app }) => {
+    await app.open({
+      expenses: [expense({ categories: ["shopping", "food", "treats"] })],
+    });
+
+    await expect(app.categoriesOf("Lunch")).toHaveText("food, shopping, treats");
+  });
+
+  test("renders an expense stored without categories", async ({ app }) => {
+    await app.open({
+      expenses: [
+        { id: 1, amount: 10, description: "Lunch", date: "2026-02-12" },
+      ],
+    });
+
+    await expect(app.expenseItem("Lunch")).toBeVisible();
+    await expect(app.categoriesOf("Lunch")).toHaveCount(0);
+  });
+
+  test("keeps the same day together across a month boundary", async ({
+    app,
+  }) => {
+    await app.open({
+      expenses: [
+        expense({ id: 1, description: "Last month", date: "2026-01-31" }),
+        expense({ id: 2, description: "This month", date: "2026-02-01" }),
+      ],
+    });
+
+    expect(await app.listedDays()).toEqual(["2026-02-01", "2026-01-31"]);
+  });
+
+  test("survives a long history", async ({ app }) => {
+    const expenses = Array.from({ length: 60 }, (_, index) =>
+      expense({
+        id: index + 1,
+        amount: 1,
+        description: "Item " + index,
+        date: "2026-02-" + String((index % 28) + 1).padStart(2, "0"),
+      }),
+    );
+
+    await app.open({ expenses });
+
+    await expect(app.expenseItems).toHaveCount(60);
+    await expect(app.dayGroups).toHaveCount(28);
+  });
+
+  test("drops the empty message as soon as an expense exists", async ({
+    app,
+  }) => {
+    await app.open();
+    await expect(app.emptyMessage).toBeVisible();
+
+    await app.addExpense({ amount: "1", description: "Coffee" });
+
+    await expect(app.emptyMessage).toHaveCount(0);
+  });
+});

--- a/web/e2e/export.spec.js
+++ b/web/e2e/export.spec.js
@@ -1,0 +1,90 @@
+// Exporting in a plain browser hands the file to the download machinery; the
+// Android branch is covered in android-bridge.spec.js.
+import { test, expect, downloadedText } from "./fixtures.js";
+
+const expenses = [
+  {
+    id: 1,
+    amount: 12.5,
+    description: "Groceries",
+    date: "2026-02-12",
+    categories: ["food", "shopping"],
+  },
+  {
+    id: 2,
+    amount: 3.25,
+    description: "Coffee",
+    date: "2026-02-10",
+    categories: [],
+  },
+];
+
+const exportFile = async (app) => {
+  const download = app.page.waitForEvent("download");
+  await app.exportButton.click();
+  return download;
+};
+
+test.describe("exporting expenses", () => {
+  test("downloads a file named for today", async ({ app }) => {
+    await app.open({ now: "2026-02-12T12:00:00Z", expenses });
+
+    const download = await exportFile(app);
+
+    expect(download.suggestedFilename()).toBe("moneta-2026-02-12.json");
+  });
+
+  test("writes the stored JSON shape", async ({ app }) => {
+    await app.open({ expenses });
+
+    const contents = await downloadedText(await exportFile(app));
+
+    expect(JSON.parse(contents)).toEqual(expenses);
+    // `serializeExpenses` indents with two spaces, and dates stay text.
+    expect(contents).toContain('\n  {\n    "id": 1,');
+    expect(contents).toContain('"date": "2026-02-12"');
+  });
+
+  test("exports what is on screen, edits included", async ({ app }) => {
+    await app.open({ expenses });
+    await app.openExpense("Coffee");
+    await app.fillForm({ amount: "4", categories: "drinks" });
+    await app.submit();
+    await expect(app.modal).toHaveCount(0);
+
+    const contents = await downloadedText(await exportFile(app));
+
+    expect(JSON.parse(contents)).toEqual([
+      expenses[0],
+      { ...expenses[1], amount: 4, categories: ["drinks"] },
+    ]);
+    expect(contents).toBe(await app.storedJson());
+  });
+
+  test("exports an empty list as an empty array", async ({ app }) => {
+    await app.open();
+
+    const contents = await downloadedText(await exportFile(app));
+
+    expect(JSON.parse(contents)).toEqual([]);
+  });
+
+  test("changes nothing on the page", async ({ app, dialogs }) => {
+    await app.open({ expenses });
+
+    await exportFile(app);
+
+    await expect(app.expenseItems).toHaveCount(2);
+    await expect(app.modal).toHaveCount(0);
+    await expect(app.saveNotice).toHaveCount(0);
+    expect(dialogs.messages).toEqual([]);
+  });
+
+  test("leaves no stray link in the document", async ({ app, page }) => {
+    await app.open({ expenses });
+
+    await exportFile(app);
+
+    await expect(page.locator("a[download]")).toHaveCount(0);
+  });
+});

--- a/web/e2e/fixtures.js
+++ b/web/e2e/fixtures.js
@@ -1,0 +1,297 @@
+// Shared test fixtures: a page object over the app's markup, a dialog recorder
+// (the app talks to the user through `alert` and `confirm`), and helpers for
+// seeding `localStorage` and for the Android bridge.
+//
+// The app carries no test hooks, so locators are built from the roles, labels
+// and Bootstrap classes `main.js` actually renders. Anything that needs to be
+// in place before the module runs — stored expenses, a fixed clock, the
+// `Android` object — is installed by `app.open()` before it navigates.
+import { test as base, expect } from "@playwright/test";
+
+export { expect };
+
+export const STORAGE_KEY = "expenses";
+
+// Records every `alert`/`confirm` the page raises. Playwright dismisses
+// dialogs itself when nothing is listening, and a dismissed `confirm` is a
+// "no", so a test that means to confirm has to say so with `acceptAll()`.
+export class Dialogs {
+  constructor(page) {
+    this.messages = [];
+    this.accepting = false;
+    page.on("dialog", async (dialog) => {
+      this.messages.push(dialog.message());
+      await (this.accepting ? dialog.accept() : dialog.dismiss());
+    });
+  }
+
+  acceptAll() {
+    this.accepting = true;
+  }
+
+  clear() {
+    this.messages.length = 0;
+  }
+
+  get last() {
+    return this.messages.at(-1);
+  }
+
+  async expectMessage(message) {
+    await expect
+      .poll(() => this.messages, { message: "expected dialog " + message })
+      .toContain(message);
+  }
+
+  async expectNone() {
+    // Nothing to wait for, so give a stray dialog a moment to arrive.
+    await expect.poll(() => this.messages).toEqual([]);
+  }
+}
+
+export class MonetaApp {
+  constructor(page) {
+    this.page = page;
+
+    this.summaryCard = page.locator(".card.mb-4");
+    this.monthTitle = this.summaryCard.locator(".card-title");
+    this.totalSpentRow = this.summaryCard.locator(".card-text");
+    // `Amount` renders the blurrable span, one level inside the coloured one.
+    this.totalSpent = this.totalSpentRow.locator("span > span");
+
+    this.expenseCard = page.locator(".card.mt-4");
+    this.emptyMessage = this.expenseCard.locator("li.text-muted");
+    this.importButton = page.getByTitle("Import Expenses");
+    this.exportButton = page.getByTitle("Export Expenses");
+    this.dayGroups = this.expenseCard.locator("li.bg-light.p-0");
+    this.dayHeadings = this.expenseCard.locator("li.bg-light > strong");
+    this.expenseItems = this.expenseCard.locator("li.list-group-item.d-flex");
+    this.newExpenseButton = page.locator("button.fixed-bottom-right");
+
+    this.modal = page.locator(".modal");
+    this.modalTitle = this.modal.locator(".modal-title");
+    this.amountInput = page.locator("#expense-amount");
+    this.descriptionInput = page.locator("#expense-description");
+    this.dateInput = page.locator("#expense-date");
+    this.categoriesInput = page.locator("#expense-categories");
+    this.closeButton = this.modal.locator(".btn-close");
+    this.cancelButton = this.modal.getByRole("button", { name: "Cancel" });
+    this.deleteButton = this.modal.getByRole("button", { name: "Delete" });
+    this.submitButton = this.modal.locator("button.btn-primary");
+
+    this.saveNotice = page.locator(".bubble");
+    this.version = page.locator(".version");
+  }
+
+  // `expenses` are seeded in stored form (`date` as YYYY-MM-DD); `now` fixes
+  // the clock; `android` installs a recording stand-in for the WebView bridge.
+  async open({ expenses, now, android = false } = {}) {
+    if (now) {
+      this.fixedTime = new Date(now).getTime();
+      await this.page.clock.setFixedTime(now);
+    }
+    // The script runs on every navigation, so it seeds only an empty device:
+    // a reload has to show what the app itself stored.
+    if (expenses)
+      await this.page.addInitScript(
+        ([key, json]) => {
+          if (window.localStorage.getItem(key) === null)
+            window.localStorage.setItem(key, json);
+        },
+        [STORAGE_KEY, JSON.stringify(expenses)],
+      );
+    if (android) await installAndroidBridge(this.page);
+    await this.page.goto("/");
+    await expect(this.expenseCard).toBeVisible();
+  }
+
+  // --- reading the page -----------------------------------------------
+
+  dayGroup(isoDate) {
+    return this.dayGroups.filter({ hasText: isoDate });
+  }
+
+  dayTotal(isoDate) {
+    return this.dayGroup(isoDate).locator("strong > span > span");
+  }
+
+  expensesOf(isoDate) {
+    return this.dayGroup(isoDate).locator("li.list-group-item.d-flex");
+  }
+
+  expenseItem(description) {
+    return this.expenseItems.filter({ hasText: description });
+  }
+
+  amountOf(description) {
+    return this.expenseItem(description).locator("span.text-danger > span");
+  }
+
+  categoriesOf(description) {
+    return this.expenseItem(description).locator(".text-info");
+  }
+
+  // The descriptions in the order they are rendered, days and all.
+  async listedDescriptions() {
+    return this.expenseItems.locator("div > span").allInnerTexts();
+  }
+
+  async listedDays() {
+    return this.expenseCard
+      .locator("li.bg-light > strong > span:first-child")
+      .allInnerTexts();
+  }
+
+  // --- driving the page -----------------------------------------------
+
+  async openNewExpense() {
+    await this.newExpenseButton.click();
+    await expect(this.modal).toBeVisible();
+  }
+
+  async openExpense(description) {
+    await this.expenseItem(description).locator("div").first().click();
+    await expect(this.modal).toBeVisible();
+  }
+
+  async fillForm({ amount, description, date, categories }) {
+    if (amount !== undefined) await this.amountInput.fill(amount);
+    if (description !== undefined)
+      await this.descriptionInput.fill(description);
+    if (date !== undefined) await this.dateInput.fill(date);
+    if (categories !== undefined) await this.categoriesInput.fill(categories);
+  }
+
+  async submit() {
+    await this.submitButton.click();
+  }
+
+  // Fills the new-expense dialog and saves it, leaving the dialog closed.
+  async addExpense(fields) {
+    await this.openNewExpense();
+    await this.fillForm(fields);
+    await this.submit();
+    await expect(this.modal).toBeHidden();
+  }
+
+  // --- storage ---------------------------------------------------------
+
+  async storedJson() {
+    return this.page.evaluate(
+      (key) => window.localStorage.getItem(key),
+      STORAGE_KEY,
+    );
+  }
+
+  async stored() {
+    const json = await this.storedJson();
+    return json === null ? null : JSON.parse(json);
+  }
+
+  // --- the clock -------------------------------------------------------
+
+  // Moves a fixed clock forward. Ids are creation timestamps, so a test that
+  // adds several expenses under a stopped clock would mint one id for all of
+  // them, and they would then be edited and deleted together.
+  async tick(milliseconds = 1000) {
+    if (this.fixedTime === undefined)
+      throw new Error("tick() needs the clock fixed by open({ now })");
+    this.fixedTime += milliseconds;
+    await this.page.clock.setFixedTime(new Date(this.fixedTime));
+  }
+
+  // The browser's today, in the context's timezone rather than Node's.
+  async todayIso() {
+    return this.page.evaluate(() => {
+      const date = new Date();
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const day = String(date.getDate()).padStart(2, "0");
+      return date.getFullYear() + "-" + month + "-" + day;
+    });
+  }
+
+  async isoDaysFromToday(days) {
+    return this.page.evaluate((days) => {
+      const date = new Date();
+      date.setDate(date.getDate() + days);
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const day = String(date.getDate()).padStart(2, "0");
+      return date.getFullYear() + "-" + month + "-" + day;
+    }, days);
+  }
+
+  async monthName() {
+    return this.page.evaluate(() =>
+      new Date().toLocaleString("default", { month: "long" }),
+    );
+  }
+}
+
+// A stand-in for the object `MainActivity` injects, recording what the app
+// asks of it. `Android.pickFile` takes a callback the host calls back with the
+// file's text; `respondToPickFile` plays the host's part.
+export async function installAndroidBridge(page) {
+  await page.addInitScript(() => {
+    window.__android = { createFile: [], pickFile: 0 };
+    window.Android = {
+      createFile(filename, content) {
+        window.__android.createFile.push({ filename, content });
+      },
+      pickFile(callback) {
+        window.__android.pickFile += 1;
+        window.__androidPickFileCallback = callback;
+      },
+    };
+  });
+}
+
+export function androidCalls(page) {
+  return page.evaluate(() => window.__android);
+}
+
+export async function respondToPickFile(page, json) {
+  await page.evaluate((json) => window.__androidPickFileCallback(json), json);
+}
+
+// Hands a file to the import flow. The `<input type=file>` is created and
+// clicked from script, so Playwright's file chooser has nothing to attach to;
+// the file is planted on the input and the change event dispatched instead.
+// A `content` of null plays the user backing out of the file picker.
+export async function importFile(app, { name = "moneta.json", content } = {}) {
+  await app.page.evaluate(
+    ([name, content]) => {
+      const nativeClick = HTMLInputElement.prototype.click;
+      HTMLInputElement.prototype.click = function () {
+        if (this.type !== "file") return nativeClick.call(this);
+        HTMLInputElement.prototype.click = nativeClick;
+        if (content !== null) {
+          const transfer = new DataTransfer();
+          transfer.items.add(
+            new File([content], name, { type: "application/json" }),
+          );
+          this.files = transfer.files;
+        }
+        this.dispatchEvent(new Event("change"));
+      };
+    },
+    [name, content ?? null],
+  );
+  await app.importButton.click();
+}
+
+// The text of a file the page offered for download.
+export async function downloadedText(download) {
+  const stream = await download.createReadStream();
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+export const test = base.extend({
+  app: async ({ page }, use) => {
+    await use(new MonetaApp(page));
+  },
+  dialogs: async ({ page }, use) => {
+    await use(new Dialogs(page));
+  },
+});

--- a/web/e2e/import.spec.js
+++ b/web/e2e/import.spec.js
@@ -1,0 +1,201 @@
+// Importing discards whatever is on the device, so every failure path has to
+// leave the existing expenses alone.
+import { test, expect, importFile } from "./fixtures.js";
+
+const existing = [
+  {
+    id: 1,
+    amount: 12.5,
+    description: "Groceries",
+    date: "2026-02-12",
+    categories: ["food"],
+  },
+];
+
+const imported = [
+  {
+    id: 10,
+    amount: 5,
+    description: "Bus",
+    date: "2026-02-11",
+    categories: ["travel"],
+  },
+  {
+    id: 11,
+    amount: 7.5,
+    description: "Lunch",
+    date: "2026-02-12",
+    categories: [],
+  },
+];
+
+const json = (value) => JSON.stringify(value, null, 2);
+
+test.describe("importing expenses", () => {
+  test.beforeEach(async ({ app }) => {
+    await app.open({ now: "2026-02-12T12:00:00Z", expenses: existing });
+  });
+
+  test("replaces the expenses on the device", async ({ app, dialogs }) => {
+    await importFile(app, { content: json(imported) });
+
+    await expect(app.expenseItems).toHaveCount(2);
+    await expect(app.expenseItem("Groceries")).toHaveCount(0);
+    await expect(app.expenseItem("Bus")).toBeVisible();
+    await expect(app.amountOf("Lunch")).toHaveText("-$7.50");
+    await expect(app.categoriesOf("Bus")).toHaveText("travel");
+    expect(dialogs.messages).toEqual([]);
+  });
+
+  test("groups and totals what it imported", async ({ app }) => {
+    await importFile(app, { content: json(imported) });
+
+    expect(await app.listedDays()).toEqual(["2026-02-12", "2026-02-11"]);
+    await expect(app.dayTotal("2026-02-12")).toHaveText("$7.50");
+    await expect(app.dayTotal("2026-02-11")).toHaveText("$5.00");
+    await expect(app.totalSpent).toHaveText("$12.50");
+  });
+
+  test("saves the imported expenses", async ({ app }) => {
+    await importFile(app, { content: json(imported) });
+
+    await expect(app.saveNotice).toHaveText("Saved");
+    expect(await app.stored()).toEqual(imported);
+  });
+
+  test("survives a reload", async ({ app, page }) => {
+    await importFile(app, { content: json(imported) });
+    await expect(app.expenseItems).toHaveCount(2);
+
+    await page.reload();
+
+    await expect(app.expenseItems).toHaveCount(2);
+    await expect(app.expenseItem("Bus")).toBeVisible();
+  });
+
+  test("sorts the categories it reads", async ({ app }) => {
+    await importFile(app, {
+      content: json([
+        { ...imported[0], categories: ["travel", "bus", "commute"] },
+      ]),
+    });
+
+    await expect(app.categoriesOf("Bus")).toHaveText("bus, commute, travel");
+    expect(await app.stored()).toEqual([
+      expect.objectContaining({ categories: ["bus", "commute", "travel"] }),
+    ]);
+  });
+
+  test("accepts an expense stored without categories", async ({ app }) => {
+    await importFile(app, {
+      content: json([{ id: 10, amount: 5, description: "Bus", date: "2026-02-11" }]),
+    });
+
+    await expect(app.expenseItem("Bus")).toBeVisible();
+    await expect(app.categoriesOf("Bus")).toHaveCount(0);
+  });
+
+  test("an empty file clears the list", async ({ app }) => {
+    await importFile(app, { content: "[]" });
+
+    await expect(app.emptyMessage).toBeVisible();
+    await expect(app.totalSpent).toHaveText("$0.00");
+    expect(await app.stored()).toEqual([]);
+  });
+
+  test("backing out of the file picker changes nothing", async ({
+    app,
+    dialogs,
+  }) => {
+    await importFile(app, { content: null });
+
+    await expect(app.expenseItem("Groceries")).toBeVisible();
+    expect(dialogs.messages).toEqual([]);
+    expect(await app.stored()).toEqual(existing);
+  });
+
+  test.describe("a file it cannot use", () => {
+    const rejects = (name, content, message) =>
+      test(name, async ({ app, dialogs }) => {
+        await importFile(app, { content });
+
+        await dialogs.expectMessage(message);
+        await expect(app.expenseItems).toHaveCount(1);
+        await expect(app.expenseItem("Groceries")).toBeVisible();
+        expect(await app.stored()).toEqual(existing);
+      });
+
+    rejects(
+      "is not JSON at all",
+      "this is not json",
+      "Failed to import expenses: Unexpected token 'h', \"this is not json\" is not valid JSON",
+    );
+
+    rejects(
+      "is JSON but not a list",
+      json({ id: 1 }),
+      "Failed to import expenses: JSON.parse(...).map is not a function",
+    );
+
+    rejects(
+      "holds an expense with no id",
+      json([{ amount: 5, description: "Bus", date: "2026-02-11" }]),
+      "File contains errors.",
+    );
+
+    rejects(
+      "holds an expense with no amount",
+      json([{ id: 10, description: "Bus", date: "2026-02-11" }]),
+      "File contains errors.",
+    );
+
+    rejects(
+      "holds an expense with a blank description",
+      json([{ id: 10, amount: 5, description: "  ", date: "2026-02-11" }]),
+      "File contains errors.",
+    );
+
+    rejects(
+      "holds an expense with an unreadable date",
+      json([{ id: 10, amount: 5, description: "Bus", date: "not a date" }]),
+      "File contains errors.",
+    );
+
+    rejects(
+      "holds an expense dated in the future",
+      json([{ id: 10, amount: 5, description: "Bus", date: "2026-02-13" }]),
+      "File contains errors.",
+    );
+
+    test("rejects the whole file for one bad expense", async ({
+      app,
+      dialogs,
+    }) => {
+      await importFile(app, {
+        content: json([imported[0], { ...imported[1], amount: -1 }]),
+      });
+
+      await dialogs.expectMessage("File contains errors.");
+      await expect(app.expenseItem("Bus")).toHaveCount(0);
+      await expect(app.expenseItem("Groceries")).toBeVisible();
+    });
+
+    test("logs what was wrong with each expense", async ({ app }) => {
+      const logged = [];
+      app.page.on("console", (message) => {
+        if (message.type() === "error") logged.push(message.text());
+      });
+
+      await importFile(app, {
+        content: json([
+          { ...imported[0], amount: 0 },
+          { ...imported[1], description: "" },
+        ]),
+      });
+
+      await expect
+        .poll(() => logged)
+        .toEqual(["Invalid amount.", "Description cannot be empty."]);
+    });
+  });
+});

--- a/web/e2e/journey.spec.js
+++ b/web/e2e/journey.spec.js
@@ -1,0 +1,90 @@
+// One run through the app the way it is actually used, start to finish.
+import { test, expect, downloadedText, importFile } from "./fixtures.js";
+
+test("a week of spending, exported and imported back", async ({
+  app,
+  page,
+  dialogs,
+}) => {
+  await app.open({ now: "2026-02-12T12:00:00Z" });
+  await expect(app.emptyMessage).toBeVisible();
+
+  await app.addExpense({
+    amount: "42.10",
+    description: "Weekly shop",
+    date: "2026-02-09",
+    categories: "food",
+  });
+  // The clock is stopped, so it is nudged between saves: an id is the moment
+  // the expense was created, and a day lists its expenses newest first.
+  await app.tick();
+  await app.addExpense({
+    amount: "2.80",
+    description: "Coffee",
+    date: "2026-02-12",
+    categories: "drinks",
+  });
+  await app.tick();
+  await app.addExpense({
+    amount: "18.00",
+    description: "Cinema",
+    date: "2026-02-12",
+    categories: "fun",
+  });
+
+  await expect(app.expenseItems).toHaveCount(3);
+  expect(await app.listedDays()).toEqual(["2026-02-12", "2026-02-09"]);
+  expect(await app.listedDescriptions()).toEqual([
+    "Cinema",
+    "Coffee",
+    "Weekly shop",
+  ]);
+  await expect(app.dayTotal("2026-02-12")).toHaveText("$20.80");
+  await expect(app.totalSpent).toHaveText("$62.90");
+
+  // The cinema ticket cost more than remembered, and the popcorn counts too.
+  await app.openExpense("Cinema");
+  await app.fillForm({ amount: "23.50", categories: "fun snacks" });
+  await app.submit();
+  await expect(app.amountOf("Cinema")).toHaveText("-$23.50");
+  await expect(app.categoriesOf("Cinema")).toHaveText("fun, snacks");
+  await expect(app.totalSpent).toHaveText("$68.40");
+
+  // The coffee was someone else's round.
+  dialogs.acceptAll();
+  await app.openExpense("Coffee");
+  await app.deleteButton.click();
+  await expect(app.expenseItem("Coffee")).toHaveCount(0);
+  await expect(app.totalSpent).toHaveText("$65.60");
+  expect(dialogs.messages).toEqual(["Are you sure?"]);
+  dialogs.clear();
+
+  // Check the numbers, then hide them again.
+  await app.totalSpentRow.click();
+  await expect(app.totalSpent).toHaveClass("");
+  await app.totalSpentRow.click();
+  await expect(app.totalSpent).toHaveClass("blur-text");
+
+  const download = page.waitForEvent("download");
+  await app.exportButton.click();
+  const backup = await downloadedText(await download);
+  expect(JSON.parse(backup)).toEqual([
+    expect.objectContaining({ description: "Weekly shop", amount: 42.1 }),
+    expect.objectContaining({ description: "Cinema", amount: 23.5 }),
+  ]);
+
+  // A reload brings everything back from the device.
+  await page.reload();
+  await expect(app.expenseItems).toHaveCount(2);
+  await expect(app.totalSpent).toHaveText("$65.60");
+
+  // A stray import wipes it out; the backup puts it back.
+  await importFile(app, { content: "[]" });
+  await expect(app.emptyMessage).toBeVisible();
+
+  await importFile(app, { content: backup });
+  await expect(app.expenseItems).toHaveCount(2);
+  await expect(app.totalSpent).toHaveText("$65.60");
+  expect(await app.storedJson()).toBe(backup);
+  expect(dialogs.messages).toEqual([]);
+});

--- a/web/e2e/modal.spec.js
+++ b/web/e2e/modal.spec.js
@@ -1,0 +1,129 @@
+// How the dialog itself behaves: real typing rather than `fill`, the backdrop,
+// and the keys a phone keyboard sends.
+import { test, expect } from "./fixtures.js";
+
+const groceries = {
+  id: 1,
+  amount: 12.5,
+  description: "Groceries",
+  date: "2026-02-12",
+  categories: ["food"],
+};
+
+test.describe("the expense dialog", () => {
+  test.beforeEach(async ({ app }) => {
+    await app.open({ now: "2026-02-12T12:00:00Z", expenses: [groceries] });
+  });
+
+  test("takes what is typed key by key", async ({ app }) => {
+    await app.openNewExpense();
+
+    await app.amountInput.pressSequentially("7.25");
+    await app.descriptionInput.pressSequentially("Cinema");
+    await app.categoriesInput.pressSequentially("fun");
+    await app.submit();
+
+    await expect(app.modal).toHaveCount(0);
+    await expect(app.amountOf("Cinema")).toHaveText("-$7.25");
+    await expect(app.categoriesOf("Cinema")).toHaveText("fun");
+  });
+
+  test("ignores letters typed into the amount", async ({ app, dialogs }) => {
+    await app.openNewExpense();
+
+    await app.amountInput.pressSequentially("abc");
+    await app.descriptionInput.fill("Cinema");
+    await app.submit();
+
+    await expect(app.amountInput).toHaveValue("");
+    await dialogs.expectMessage("Invalid amount.");
+  });
+
+  test("edits an existing value rather than replacing it", async ({ app }) => {
+    await app.openExpense("Groceries");
+
+    await app.descriptionInput.press("End");
+    await app.descriptionInput.pressSequentially(" and wine");
+    await app.submit();
+
+    await expect(app.expenseItem("Groceries and wine")).toBeVisible();
+  });
+
+  test("does not reload the page when Enter is pressed", async ({
+    app,
+    page,
+  }) => {
+    await page.evaluate(() => (window.__stillHere = true));
+    await app.openNewExpense();
+
+    await app.descriptionInput.fill("Cinema");
+    await app.descriptionInput.press("Enter");
+
+    await expect(app.modal).toBeVisible();
+    expect(await page.evaluate(() => window.__stillHere)).toBe(true);
+  });
+
+  test("covers the page with a dimmed backdrop", async ({ app }) => {
+    await app.openNewExpense();
+
+    await expect(app.modal).toHaveCSS("display", "block");
+    await expect(app.modal).toHaveCSS(
+      "background-color",
+      "rgba(0, 0, 0, 0.5)",
+    );
+  });
+
+  test("keeps the list out of reach behind the backdrop", async ({
+    app,
+    page,
+  }) => {
+    await app.openNewExpense();
+
+    // Where the expense row sits, but the dialog is in front of it.
+    await page.mouse.click(200, 400);
+
+    await expect(app.modal).toBeVisible();
+    await expect(app.modalTitle).toHaveText("New Expense");
+  });
+
+  test("stays open until Cancel, the close button or a save", async ({
+    app,
+    page,
+  }) => {
+    await app.openNewExpense();
+
+    await page.keyboard.press("Escape");
+    await expect(app.modal).toBeVisible();
+
+    await app.cancelButton.click();
+    await expect(app.modal).toHaveCount(0);
+  });
+
+  test("opens one dialog at a time", async ({ app, page }) => {
+    await app.openExpense("Groceries");
+
+    await expect(page.locator(".modal")).toHaveCount(1);
+    await expect(app.modalTitle).toHaveText("Edit Expense");
+  });
+
+  test("fits a narrow phone screen", async ({ app, page }) => {
+    await page.setViewportSize({ width: 320, height: 640 });
+    await app.openNewExpense();
+
+    for (const input of [
+      app.amountInput,
+      app.descriptionInput,
+      app.dateInput,
+      app.categoriesInput,
+    ])
+      await expect(input).toBeInViewport();
+    await expect(app.submitButton).toBeInViewport();
+    expect(
+      await page.evaluate(
+        () =>
+          document.documentElement.scrollWidth <=
+          document.documentElement.clientWidth,
+      ),
+    ).toBe(true);
+  });
+});

--- a/web/e2e/persistence.spec.js
+++ b/web/e2e/persistence.spec.js
@@ -1,0 +1,146 @@
+// Expenses live in `localStorage` on the device; there is no server. What is
+// stored is a compatibility boundary, so these tests read the raw JSON.
+import { test, expect } from "./fixtures.js";
+
+const stored = [
+  {
+    id: 1,
+    amount: 12.5,
+    description: "Groceries",
+    date: "2026-02-12",
+    categories: ["food"],
+  },
+  {
+    id: 2,
+    amount: 3.25,
+    description: "Coffee",
+    date: "2026-02-10",
+    categories: [],
+  },
+];
+
+test.describe("keeping expenses on the device", () => {
+  test("shows what was stored before", async ({ app }) => {
+    await app.open({ expenses: stored });
+
+    await expect(app.expenseItems).toHaveCount(2);
+    await expect(app.amountOf("Groceries")).toHaveText("-$12.50");
+    await expect(app.dayGroups).toHaveCount(2);
+  });
+
+  test("an added expense survives a reload", async ({ app, page }) => {
+    await app.open({ now: "2026-02-12T12:00:00Z" });
+    await app.addExpense({
+      amount: "8",
+      description: "Dinner",
+      categories: "food out",
+    });
+
+    await page.reload();
+
+    await expect(app.expenseItem("Dinner")).toBeVisible();
+    await expect(app.amountOf("Dinner")).toHaveText("-$8.00");
+    await expect(app.categoriesOf("Dinner")).toHaveText("food, out");
+    await expect(app.dayGroup("2026-02-12")).toBeVisible();
+  });
+
+  test("an edit survives a reload", async ({ app, page }) => {
+    await app.open({ expenses: stored });
+    await app.openExpense("Coffee");
+    await app.fillForm({ amount: "4.75", description: "Tea" });
+    await app.submit();
+
+    await page.reload();
+
+    await expect(app.expenseItem("Tea")).toBeVisible();
+    await expect(app.amountOf("Tea")).toHaveText("-$4.75");
+    await expect(app.expenseItem("Coffee")).toHaveCount(0);
+  });
+
+  test("a deletion survives a reload", async ({ app, page, dialogs }) => {
+    await app.open({ expenses: stored });
+    dialogs.acceptAll();
+    await app.openExpense("Groceries");
+    await app.deleteButton.click();
+    await expect(app.modal).toHaveCount(0);
+
+    await page.reload();
+
+    await expect(app.expenseItems).toHaveCount(1);
+    await expect(app.expenseItem("Groceries")).toHaveCount(0);
+  });
+
+  test("stores the date as the calendar day the user picked", async ({
+    app,
+  }) => {
+    await app.open();
+
+    await app.addExpense({
+      amount: "5",
+      description: "Bus",
+      date: "2026-02-12",
+    });
+
+    // Read as UTC midnight this would slip a day west of the meridian.
+    expect(await app.stored()).toEqual([
+      expect.objectContaining({ date: "2026-02-12" }),
+    ]);
+    await expect(app.dayGroup("2026-02-12")).toBeVisible();
+    await app.openExpense("Bus");
+    await expect(app.dateInput).toHaveValue("2026-02-12");
+  });
+
+  test("writes under the `expenses` key, nothing else", async ({
+    app,
+    page,
+  }) => {
+    await app.open();
+    await app.addExpense({ amount: "5", description: "Bus" });
+
+    expect(await page.evaluate(() => Object.keys(window.localStorage))).toEqual([
+      "expenses",
+    ]);
+  });
+
+  test("starts empty on a device that has never saved", async ({ app }) => {
+    await app.open();
+
+    await expect(app.emptyMessage).toBeVisible();
+    expect(await app.stored()).toBe(null);
+  });
+});
+
+test.describe("the Saved bubble", () => {
+  test("appears on a save and fades after three seconds", async ({ app }) => {
+    await app.open();
+
+    await app.addExpense({ amount: "5", description: "Bus" });
+
+    await expect(app.saveNotice).toHaveText("Saved");
+    await expect(app.saveNotice).toHaveAttribute("role", "alert");
+    await expect(app.saveNotice).toHaveCount(0, { timeout: 6000 });
+  });
+
+  test("a second save restarts the three seconds", async ({ app }) => {
+    await app.open();
+    await app.addExpense({ amount: "5", description: "Bus" });
+    await expect(app.saveNotice).toBeVisible();
+
+    await app.page.waitForTimeout(2000);
+    await app.addExpense({ amount: "6", description: "Train" });
+
+    // The first timer would have fired by now; the second keeps it up.
+    await app.page.waitForTimeout(1500);
+    await expect(app.saveNotice).toHaveText("Saved");
+    await expect(app.saveNotice).toHaveCount(0, { timeout: 6000 });
+  });
+
+  test("stays away when nothing is saved", async ({ app }) => {
+    await app.open({ expenses: stored });
+
+    await app.openExpense("Coffee");
+    await app.cancelButton.click();
+
+    await expect(app.saveNotice).toHaveCount(0);
+  });
+});

--- a/web/e2e/server.js
+++ b/web/e2e/server.js
@@ -1,0 +1,68 @@
+// Serves the app for the end-to-end tests the way `scripts/build` lays it out:
+// the same URL names, so `index.html`'s import map resolves exactly as it does
+// on the device. `scripts/serve` cannot be used here because it serves the
+// *built* assets, which need a full Android build to exist.
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { dirname, extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const WEB_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
+const MODULES = join(WEB_DIR, "node_modules");
+const ICONS = join(MODULES, "@material-design-icons/svg/outlined");
+
+// Mirrors the copy list in `scripts/build`; keep the two in step.
+const FILES = {
+  "/index.html": join(WEB_DIR, "index.html"),
+  "/main.js": join(WEB_DIR, "main.js"),
+  "/bootstrap.css": join(MODULES, "bootstrap/dist/css/bootstrap.css"),
+  "/solid.js": join(MODULES, "solid-js/dist/solid.js"),
+  "/solid-web.js": join(MODULES, "solid-js/web/dist/web.js"),
+  "/solid-store.js": join(MODULES, "solid-js/store/dist/store.js"),
+  "/solid-html.js": join(MODULES, "solid-js/html/dist/html.js"),
+  "/file_download.svg": join(ICONS, "file_download.svg"),
+  "/file_upload.svg": join(ICONS, "file_upload.svg"),
+};
+
+const TYPES = {
+  ".css": "text/css; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".svg": "image/svg+xml",
+};
+
+// `scripts/build` substitutes the commit date and hash; the tests only need the
+// placeholder gone and a value they can assert on.
+export const VERSION = "e2e-test-build";
+
+const server = createServer(async (request, response) => {
+  const path = new URL(request.url, "http://localhost").pathname;
+  const file = FILES[path === "/" ? "/index.html" : path];
+  if (!file) {
+    response.writeHead(404, { "content-type": "text/plain" });
+    response.end("Not found: " + path);
+    return;
+  }
+  try {
+    let body = await readFile(file);
+    if (file.endsWith("index.html"))
+      body = body.toString().replaceAll("%VERSION%", VERSION);
+    response.writeHead(200, {
+      "content-type": TYPES[extname(file)] ?? "application/octet-stream",
+      // Every test navigation must see the file on disk, never a cached copy.
+      "cache-control": "no-store",
+    });
+    response.end(body);
+  } catch (error) {
+    response.writeHead(500, { "content-type": "text/plain" });
+    response.end(String(error));
+  }
+});
+
+// The specs import `VERSION` from here, so only listen when run as a program.
+if (resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  const port = Number(process.argv[2] ?? process.env.PORT ?? 8099);
+  server.listen(port, "127.0.0.1", () => {
+    console.log("moneta e2e server on http://127.0.0.1:" + port);
+  });
+}

--- a/web/e2e/summary-card.spec.js
+++ b/web/e2e/summary-card.spec.js
@@ -1,0 +1,90 @@
+// The summary card totals the current calendar month, so these tests pin the
+// clock. Noon UTC keeps both timezone projects on the same calendar day.
+import { test, expect } from "./fixtures.js";
+
+const FEBRUARY = "2026-02-12T12:00:00Z";
+
+const expense = (overrides) => ({
+  id: 1,
+  amount: 10,
+  description: "Lunch",
+  date: "2026-02-12",
+  categories: [],
+  ...overrides,
+});
+
+test.describe("the monthly summary", () => {
+  test("names the current month", async ({ app }) => {
+    await app.open({ now: FEBRUARY });
+
+    await expect(app.monthTitle).toHaveText("February");
+  });
+
+  test("totals only this month's expenses", async ({ app }) => {
+    await app.open({
+      now: FEBRUARY,
+      expenses: [
+        expense({ id: 1, amount: 10, date: "2026-02-01" }),
+        expense({ id: 2, amount: 2.5, date: "2026-02-12" }),
+        expense({ id: 3, amount: 100, date: "2026-01-31" }),
+        expense({ id: 4, amount: 100, date: "2025-02-12" }),
+      ],
+    });
+
+    await expect(app.totalSpent).toHaveText("$12.50");
+  });
+
+  test("counts the first and last day of the month", async ({ app }) => {
+    await app.open({
+      now: FEBRUARY,
+      expenses: [
+        expense({ id: 1, amount: 1, date: "2026-02-01" }),
+        expense({ id: 2, amount: 2, date: "2026-02-28" }),
+      ],
+    });
+
+    await expect(app.totalSpent).toHaveText("$3.00");
+  });
+
+  test("shows nothing spent when the month is empty", async ({ app }) => {
+    await app.open({
+      now: FEBRUARY,
+      expenses: [expense({ amount: 100, date: "2026-01-15" })],
+    });
+
+    await expect(app.totalSpent).toHaveText("$0.00");
+    await expect(app.expenseItems).toHaveCount(1);
+  });
+
+  test("grows as expenses are added and shrinks as they go", async ({
+    app,
+    dialogs,
+  }) => {
+    await app.open({ now: FEBRUARY, expenses: [expense({ amount: 10 })] });
+    await expect(app.totalSpent).toHaveText("$10.00");
+
+    await app.addExpense({
+      amount: "5",
+      description: "Coffee",
+      date: "2026-02-12",
+    });
+    await expect(app.totalSpent).toHaveText("$15.00");
+
+    dialogs.acceptAll();
+    await app.openExpense("Coffee");
+    await app.deleteButton.click();
+
+    await expect(app.totalSpent).toHaveText("$10.00");
+  });
+
+  test("follows an expense edited out of this month", async ({ app }) => {
+    await app.open({ now: FEBRUARY, expenses: [expense({ amount: 10 })] });
+
+    await app.openExpense("Lunch");
+    await app.fillForm({ date: "2026-01-12" });
+    await app.submit();
+
+    await expect(app.totalSpent).toHaveText("$0.00");
+    await expect(app.expenseItem("Lunch")).toBeVisible();
+  });
+});

--- a/web/e2e/validation.spec.js
+++ b/web/e2e/validation.spec.js
@@ -1,0 +1,138 @@
+// The dialog rejects an expense with an `alert` and stays open. The same
+// `expenseError` check guards the import path, so the wording is shared.
+import { test, expect } from "./fixtures.js";
+
+test.describe("rejecting an invalid expense", () => {
+  test.beforeEach(async ({ app }) => {
+    await app.open();
+    await app.openNewExpense();
+  });
+
+  const rejects = (name, fields, message) =>
+    test(name, async ({ app, dialogs }) => {
+      await app.fillForm(fields);
+
+      await app.submit();
+
+      await dialogs.expectMessage(message);
+      await expect(app.modal).toBeVisible();
+      await expect(app.expenseItems).toHaveCount(0);
+      expect(await app.stored()).toBe(null);
+    });
+
+  rejects("a missing amount", { description: "Groceries" }, "Invalid amount.");
+
+  rejects(
+    "a zero amount",
+    { amount: "0", description: "Groceries" },
+    "Invalid amount.",
+  );
+
+  rejects(
+    "a negative amount",
+    { amount: "-5", description: "Groceries" },
+    "Invalid amount.",
+  );
+
+  rejects(
+    "a missing description",
+    { amount: "12.50" },
+    "Description cannot be empty.",
+  );
+
+  rejects(
+    "a description of only spaces",
+    { amount: "12.50", description: "   " },
+    "Description cannot be empty.",
+  );
+
+  rejects(
+    "a cleared date",
+    { amount: "12.50", description: "Groceries", date: "" },
+    "Invalid date.",
+  );
+
+  test("a date in the future", async ({ app, dialogs }) => {
+    await app.fillForm({
+      amount: "12.50",
+      description: "Groceries",
+      date: await app.isoDaysFromToday(1),
+    });
+
+    await app.submit();
+
+    await dialogs.expectMessage("Date cannot be in the future.");
+    await expect(app.modal).toBeVisible();
+    expect(await app.stored()).toBe(null);
+  });
+
+  test("accepts today, the edge of the future", async ({ app, dialogs }) => {
+    await app.fillForm({
+      amount: "12.50",
+      description: "Groceries",
+      date: await app.todayIso(),
+    });
+
+    await app.submit();
+
+    await expect(app.modal).toHaveCount(0);
+    await expect(app.expenseItem("Groceries")).toBeVisible();
+    expect(dialogs.messages).toEqual([]);
+  });
+
+  test("reports the amount first when several fields are wrong", async ({
+    app,
+    dialogs,
+  }) => {
+    await app.fillForm({ amount: "0", description: "", date: "" });
+
+    await app.submit();
+
+    await dialogs.expectMessage("Invalid amount.");
+    expect(dialogs.messages).toEqual(["Invalid amount."]);
+  });
+
+  test("keeps what was typed so it can be corrected", async ({
+    app,
+    dialogs,
+  }) => {
+    await app.fillForm({
+      amount: "0",
+      description: "Groceries",
+      categories: "food",
+    });
+    await app.submit();
+    await dialogs.expectMessage("Invalid amount.");
+
+    await app.amountInput.fill("12.50");
+    await app.submit();
+
+    await expect(app.modal).toHaveCount(0);
+    await expect(app.amountOf("Groceries")).toHaveText("-$12.50");
+    await expect(app.categoriesOf("Groceries")).toHaveText("food");
+  });
+});
+
+test.describe("rejecting an invalid edit", () => {
+  const groceries = {
+    id: 1,
+    amount: 12.5,
+    description: "Groceries",
+    date: "2026-02-12",
+    categories: ["food"],
+  };
+
+  test("leaves the stored expense alone", async ({ app, dialogs }) => {
+    await app.open({ expenses: [groceries] });
+    await app.openExpense("Groceries");
+
+    await app.fillForm({ amount: "" });
+    await app.submit();
+
+    await dialogs.expectMessage("Invalid amount.");
+    await expect(app.modal).toBeVisible();
+    await expect(app.amountOf("Groceries")).toHaveText("-$12.50");
+    // Nothing was saved, so storage still holds what was seeded.
+    expect(await app.stored()).toEqual([groceries]);
+  });
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,9 @@
         "@playwright/cli": "^0.1.17",
         "bootstrap": "^5.3.0",
         "solid-js": "^1.9.14"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.56.1"
       }
     },
     "node_modules/@material-design-icons/svg": {
@@ -31,6 +34,54 @@
       },
       "bin": {
         "playwright-cli": "playwright-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"

--- a/web/package.json
+++ b/web/package.json
@@ -7,5 +7,8 @@
     "@playwright/cli": "^0.1.17",
     "bootstrap": "^5.3.0",
     "solid-js": "^1.9.14"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.56.1"
   }
 }

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -1,0 +1,40 @@
+import { defineConfig } from "@playwright/test";
+
+const PORT = Number(process.env.PORT ?? 8099);
+const BASE_URL = "http://127.0.0.1:" + PORT;
+
+// The app ships inside an Android WebView, so both projects are Chromium at a
+// phone viewport. They differ only in timezone: the unit tests run east and
+// west of UTC for the same reason, and the UI is full of dates.
+const phone = { viewport: { width: 412, height: 915 }, locale: "en-US" };
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "east-of-utc",
+      use: { ...phone, timezoneId: "Asia/Kolkata" },
+    },
+    {
+      name: "west-of-utc",
+      use: { ...phone, timezoneId: "America/New_York" },
+    },
+  ],
+  webServer: {
+    command: "node e2e/server.js " + PORT,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    stdout: "ignore",
+    stderr: "pipe",
+  },
+});


### PR DESCRIPTION
The Node tests reach only the domain layer of main.js, so nothing caught a
wiring error in the Solid components. This adds 120 end-to-end tests over the
UI: the empty app, adding, validation, editing, deleting, day grouping and
totals, the monthly summary, blurred amounts, persistence across reloads, the
Saved bubble, import and export in the browser, and the same two through a
stand-in for the Android bridge.

The suite serves the app itself from web/e2e/server.js, mapping the URL names
scripts/build produces straight onto web/ and node_modules, so it needs no
Android build. Every spec runs twice, east and west of UTC, as scripts/test
does. scripts/e2e runs it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xc24g5pjgV1DKXKY2uzyFi